### PR TITLE
debian: rebuild for Ubuntu/Jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+puppet (3.8.5-2ubuntu0.1+jammy0+exo1) focal; urgency=low
+
+  * Rebuild for Jammy
+
+ -- Cédric Dufour <cedric.dufour@exoscale.ch>  Tue, 24 May 2022 09:38:02 +0200
+
 puppet (3.8.5-2ubuntu0.1+focal0+exo2) focal; urgency=medium
 
   * Add ruby-sync runtime dependencay.

--- a/debian/control
+++ b/debian/control
@@ -9,11 +9,10 @@ Uploaders: Micah Anderson <micah@debian.org>,
  Stig Sandbeck Mathisen <ssm@debian.org>,
  Apollon Oikonomopoulos <apoikos@debian.org>
 Build-Depends:
- debhelper (>= 9~),
- dh-systemd,
- facter (<< 3),
+ debhelper (>= 12),
+ facter,
  rake,
- hiera (<< 3),
+ hiera,
 Standards-Version: 3.9.6
 Vcs-Git: git://anonscm.debian.org/pkg-puppet/puppet.git
 Vcs-Browser: http://anonscm.debian.org/cgit/pkg-puppet/puppet.git
@@ -24,9 +23,9 @@ Package: puppet-common
 Architecture: all
 Depends: ${misc:Depends},
  adduser,
- facter (<< 3),
+ facter,
  ruby-augeas,
- hiera (<< 3),
+ hiera,
  lsb-base,
  ruby | ruby-interpreter,
  ruby-rgen,

--- a/debian/patches/hail-ruby-3-0.patch
+++ b/debian/patches/hail-ruby-3-0.patch
@@ -1,0 +1,45 @@
+diff -urN puppet-3.8.5.orig/install.rb puppet-3.8.5/install.rb
+--- puppet-3.8.5.orig/install.rb	2016-01-21 16:29:51.000000000 +0100
++++ puppet-3.8.5/install.rb	2022-05-24 10:25:01.070529740 +0200
+@@ -70,7 +70,7 @@
+     if $haveftools
+       File.install(cf, ocf, 0644, true)
+     else
+-      FileUtils.install(cf, ocf, {:mode => 0644, :preserve => true, :verbose => true})
++      FileUtils.install(cf, ocf, :mode => 0644, :preserve => true, :verbose => true)
+     end
+   end
+ 
+@@ -80,7 +80,7 @@
+     if $haveftools
+       File.install(src_dll, dst_dll, 0644, true)
+     else
+-      FileUtils.install(src_dll, dst_dll, {:mode => 0644, :preserve => true, :verbose => true})
++      FileUtils.install(src_dll, dst_dll, :mode => 0644, :preserve => true, :verbose => true)
+     end
+ 
+     require 'win32/registry'
+@@ -115,9 +115,9 @@
+       File.chmod(0755, op)
+       File.install(lf, olf, 0644, true)
+     else
+-      FileUtils.makedirs(op, {:mode => 0755, :verbose => true})
++      FileUtils.makedirs(op, :mode => 0755, :verbose => true)
+       FileUtils.chmod(0755, op)
+-      FileUtils.install(lf, olf, {:mode => 0644, :preserve => true, :verbose => true})
++      FileUtils.install(lf, olf, :mode => 0644, :preserve => true, :verbose => true)
+     end
+   end
+ end
+@@ -131,9 +131,9 @@
+       File.chmod(0755, om)
+       File.install(mf, omf, 0644, true)
+     else
+-      FileUtils.makedirs(om, {:mode => 0755, :verbose => true})
++      FileUtils.makedirs(om, :mode => 0755, :verbose => true)
+       FileUtils.chmod(0755, om)
+-      FileUtils.install(mf, omf, {:mode => 0644, :preserve => true, :verbose => true})
++      FileUtils.install(mf, omf, :mode => 0644, :preserve => true, :verbose => true)
+     end
+     gzip = %x{which gzip}
+     gzip.chomp!

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,3 +8,4 @@
 0008-Default-to-systemd-if-systemd.patch
 no-openssl-monkeypatch.patch
 mute-ruby-2-7-warnings.patch
+hail-ruby-3-0.patch


### PR DESCRIPTION
CI: https://ci.internal.exoscale.ch/job/pkg-puppet/17/console

Facter 3.14.12 (rewritten in C along libboost): so far, experience has shown it appears to remain compatible with Exoscale  `/etc/facter/facts.d/*.txt` (but Puppet 3.8.x ?)

Hiera 3.2.0: so far, basic tests seems to indicate it remains compatible with Exoscale `configstore` (and anyway, is it used on client/agent side ?):

```
* cdufour@xps13-9380.cedric.exoscale.me:~/git/exoscale/puppet (cedric/sc-46906/same-player-shoot-again)
$ hiera -v
3.2.0

$ hiera -d -f yaml -c hiera-test.yaml "ssl-CA-puppet" '::sp_environment=preprod' '::service_platform=infra-vault' '::hostname=infra-vault-lab001.gv2' '::location=gv2' '::operatingsystem=Ubuntu' '::operatingsystemrelease=20.04'
DEBUG: 2022-05-24 10:47:43 +0200: Hiera YAML backend starting
DEBUG: 2022-05-24 10:47:43 +0200: Looking up ssl-CA-puppet in YAML backend
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source host/infra-vault-lab001.gv2
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source platform/preprod-infra-vault
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source platform/infra-vault
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source gv2
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source preprod
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source Ubuntu-20.04
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source Ubuntu
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source common
DEBUG: 2022-05-24 10:47:43 +0200: Looking for data source certificates
DEBUG: 2022-05-24 10:47:43 +0200: Found ssl-CA-puppet in certificates
---
cert: |
  -----BEGIN CERTIFICATE-----
  [[ ... ]]
  -----END CERTIFICATE-----
key: N/A
```
